### PR TITLE
Switch the top panel colors around

### DIFF
--- a/src/renderer/components/Tabs/style.scss
+++ b/src/renderer/components/Tabs/style.scss
@@ -8,7 +8,7 @@
 	align-items: center;
 	padding: 0px 10px;
 	&:hover {
-		background-color: #050505;
+		background-color: #2c2c2c;
 	}
 	& > span {
 		pointer-events: none;
@@ -22,7 +22,7 @@
 	}
 }
 .active {
-	background-color: #050505;
+	background-color: #2c2c2c;
 }
 
 .fakeTab {

--- a/src/renderer/components/TopPanel/style.scss
+++ b/src/renderer/components/TopPanel/style.scss
@@ -16,7 +16,7 @@
 	align-items: center;
 	padding: 6px 8px 6px 6px;
 	&:hover {
-		background-color: #2c2c2c;
+		background-color: #050505;
 		cursor: pointer;
 	}
 }
@@ -26,7 +26,7 @@
 	align-items: center;
 	padding: 0px 6px 6px 4px;
 	&:hover {
-		background-color: #2c2c2c;
+		background-color: #050505;
 		cursor: pointer;
 	}
 }

--- a/src/renderer/components/TopPanel/style.scss
+++ b/src/renderer/components/TopPanel/style.scss
@@ -2,7 +2,7 @@
 	display: grid;
 	grid-template: "a b c";
 	grid-template-columns: auto 1fr auto;
-	background-color: #2c2c2c;
+	background-color: #050505;
 }
 
 .panelButtons {
@@ -16,7 +16,7 @@
 	align-items: center;
 	padding: 6px 8px 6px 6px;
 	&:hover {
-		background-color: #050505;
+		background-color: #2c2c2c;
 		cursor: pointer;
 	}
 }
@@ -26,7 +26,7 @@
 	align-items: center;
 	padding: 0px 6px 6px 4px;
 	&:hover {
-		background-color: #050505;
+		background-color: #2c2c2c;
 		cursor: pointer;
 	}
 }


### PR DESCRIPTION
It's always bothered me that the colors in the top panel are not the way they are in the Mac/Windows app - I hope switching these values around will do what I think it does...

~~I haven't tested this yet (node-sass isn't compatible with Node v11 on Linux yet), but I'll try to get a working build on my system to get a screenshot.~~ Here we go:

![image](https://user-images.githubusercontent.com/74385/47954440-1d6c7a80-dfc5-11e8-9392-9044e053243f.png)
